### PR TITLE
security headers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ defaults:
     values:
       layout: "post"
 
+include: ['_headers']
 
 # Build settings
 

--- a/_headers
+++ b/_headers
@@ -1,0 +1,3 @@
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block

--- a/_headers
+++ b/_headers
@@ -1,3 +1,9 @@
 /*
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
+  Header set X-Content-Type-Options "nosniff"
+  Header set X-Permitted-Cross-Domain-Policies "none"
+  Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  Header set Content-Security-Policy "default-src * data:; script-src https: 'unsafe-inline' 'unsafe-eval'; style-src https: 'unsafe-inline'"
+  Header set Referrer-Policy "no-referrer-when-downgrade"
+  Header set Expect-CT: max-age=31536000, report-uri="https://your.report-uri.com/r/d/ct/report"

--- a/_headers
+++ b/_headers
@@ -1,9 +1,4 @@
 /*
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
-  X-Content-Type-Options "nosniff"
-  X-Permitted-Cross-Domain-Policies "none"
-  Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-  Content-Security-Policy "default-src * data:; script-src https: 'unsafe-inline' 'unsafe-eval'; style-src https: 'unsafe-inline'"
-  Referrer-Policy "no-referrer-when-downgrade"
-  Expect-CT: max-age=31536000, report-uri="https://your.report-uri.com/r/d/ct/report"
+  

--- a/_headers
+++ b/_headers
@@ -1,9 +1,9 @@
 /*
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
-  Header set X-Content-Type-Options "nosniff"
-  Header set X-Permitted-Cross-Domain-Policies "none"
-  Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-  Header set Content-Security-Policy "default-src * data:; script-src https: 'unsafe-inline' 'unsafe-eval'; style-src https: 'unsafe-inline'"
-  Header set Referrer-Policy "no-referrer-when-downgrade"
-  Header set Expect-CT: max-age=31536000, report-uri="https://your.report-uri.com/r/d/ct/report"
+  X-Content-Type-Options "nosniff"
+  X-Permitted-Cross-Domain-Policies "none"
+  Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  Content-Security-Policy "default-src * data:; script-src https: 'unsafe-inline' 'unsafe-eval'; style-src https: 'unsafe-inline'"
+  Referrer-Policy "no-referrer-when-downgrade"
+  Expect-CT: max-age=31536000, report-uri="https://your.report-uri.com/r/d/ct/report"


### PR DESCRIPTION
Prevent x-frame
X-Frame-Options is a security header to prevent a well-known vulnerability called Clickjacking. The header instruct browser not to open a web page in a frame or iframe based on the configuration.

Test available on https://condescending-jang-7f6e35.netlify.app/
checked on https://gf.dev/x-frame-options-test
